### PR TITLE
Always read 3 colors per pixel.

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -78,7 +78,7 @@ func (d *decoder) decode(r io.Reader, configOnly bool) (image.Image, error) {
 
 	for y := 0; y < d.height; y++ {
 		for x := 0; x < d.width; x++ {
-			_, err = d.br.Read(pixel)
+			_, err = io.ReadFull(d.br, pixel)
 			if err != nil {
 				return nil, errNotEnough
 			}


### PR DESCRIPTION
Hi, thank you for writing this!

I found a bug where when I tried to decode a PPM image, the image would look slanted after being re-encoded. I guess a full pixel wasn't always being read, because this fixes it for me.