### PR TITLE
Added support for file with depth under 255 (8bits)

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -17,7 +17,7 @@ import (
 var (
 	errBadHeader   = errors.New("ppm: invalid header")
 	errNotEnough   = errors.New("ppm: not enough image data")
-	errUnsupported = errors.New("ppm: unsupported format (maxVal > 255)")
+	errUnsupported = errors.New("ppm: unsupported format (maxVal > 255 or maxval <= 0)")
 )
 
 func init() {
@@ -135,7 +135,7 @@ func (d *decoder) decodeHeader() error {
 	d.maxVal, err = strconv.Atoi(string(headerFields[3]))
 	if err != nil {
 		return errBadHeader
-	} else if d.maxVal > 255 {
+	} else if d.maxVal > 255 || d.maxVal <= 0 {
 		return errUnsupported
 	}
 	return nil


### PR DESCRIPTION
Now maxVal can be set in range [1-255]. Most files have a 255 maxVal anyway to it won't really change how it works.

I created a ppm file with a 200 maxVal to test it with [this go file](https://gist.github.com/slashformotion/dd76f011625914612d6adc1803f1b133).