### PR TITLE
Fix potential infinite loop in header decoding

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -97,7 +97,10 @@ func (d *decoder) decodeHeader() error {
 
 	comment := false
 	for fields := 0; fields < 4; {
-		b, _ = d.br.ReadByte()
+		b, err = d.br.ReadByte()
+		if err != nil {
+		        return errBadHeader
+		}
 		if b == '#' {
 			comment = true
 		} else if !comment {

--- a/reader.go
+++ b/reader.go
@@ -99,7 +99,7 @@ func (d *decoder) decodeHeader() error {
 	for fields := 0; fields < 4; {
 		b, err = d.br.ReadByte()
 		if err != nil {
-		        return errBadHeader
+			return errBadHeader
 		}
 		if b == '#' {
 			comment = true

--- a/reader_test.go
+++ b/reader_test.go
@@ -104,6 +104,10 @@ func TestDecodeConfig(t *testing.T) {
 			WantConfig: image.Config{ColorModel: color.RGBAModel, Width: 1, Height: 1},
 		},
 		{
+			Enc:     bytes.NewBufferString(""),
+			WantErr: errors.New("ppm: invalid header"),
+		},
+		{
 			Enc:     bytes.NewBufferString("P7\n1 1\n255\n"),
 			WantErr: errors.New("ppm: invalid header"),
 		},


### PR DESCRIPTION
Currently, using the decode functions directly with an io.Reader containing no data, results in an infinite loop, and eventually a OOM condition due to an unhandled error. 